### PR TITLE
Add "scan devices" feature

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ set(SOURCES_FILES
         src/Poller/Poller.hpp
         src/Poller/PipePoller.cpp
         src/Poller/PipePoller.hpp
-        src/Packet/Commands/Scan/StartScan.cpp src/Packet/Commands/Scan/StartScan.hpp src/Packet/Responses/Scan/StartScan.cpp src/Packet/Responses/Scan/StartScan.hpp)
+        src/Packet/Commands/Scan/StartScan.cpp src/Packet/Commands/Scan/StartScan.hpp src/Packet/Responses/Scan/StartScan.cpp src/Packet/Responses/Scan/StartScan.hpp src/Packet/Events/EventPacket.hpp src/Packet/Events/DeviceFound/DeviceFound.cpp src/Packet/Events/DeviceFound/DeviceFound.hpp src/Packet/Events/Discovering/Discovering.cpp src/Packet/Events/Discovering/Discovering.hpp)
 add_executable(baBLE_linux ${SOURCES_FILES})
 
 ## Include dependencies

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,19 @@ set(SOURCES_FILES
         src/Poller/Poller.hpp
         src/Poller/PipePoller.cpp
         src/Poller/PipePoller.hpp
-        src/Packet/Commands/Scan/StartScan.cpp src/Packet/Commands/Scan/StartScan.hpp src/Packet/Responses/Scan/StartScan.cpp src/Packet/Responses/Scan/StartScan.hpp src/Packet/Events/EventPacket.hpp src/Packet/Events/DeviceFound/DeviceFound.cpp src/Packet/Events/DeviceFound/DeviceFound.hpp src/Packet/Events/Discovering/Discovering.cpp src/Packet/Events/Discovering/Discovering.hpp)
+        src/Packet/Commands/Scan/StartScan.cpp
+        src/Packet/Commands/Scan/StartScan.hpp
+        src/Packet/Responses/Scan/StartScan.cpp
+        src/Packet/Responses/Scan/StartScan.hpp
+        src/Packet/Events/EventPacket.hpp
+        src/Packet/Events/DeviceFound/DeviceFound.cpp
+        src/Packet/Events/DeviceFound/DeviceFound.hpp
+        src/Packet/Events/Discovering/Discovering.cpp
+        src/Packet/Events/Discovering/Discovering.hpp
+        src/Packet/Commands/Scan/StopScan.cpp
+        src/Packet/Commands/Scan/StopScan.hpp
+        src/Packet/Responses/Scan/StopScan.cpp
+        src/Packet/Responses/Scan/StopScan.hpp)
 add_executable(baBLE_linux ${SOURCES_FILES})
 
 ## Include dependencies

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ set(SOURCES_FILES
         src/Poller/Poller.hpp
         src/Poller/PipePoller.cpp
         src/Poller/PipePoller.hpp
-        )
+        src/Packet/Commands/Scan/StartScan.cpp src/Packet/Commands/Scan/StartScan.hpp src/Packet/Responses/Scan/StartScan.cpp src/Packet/Responses/Scan/StartScan.hpp)
 add_executable(baBLE_linux ${SOURCES_FILES})
 
 ## Include dependencies

--- a/python_interface.py
+++ b/python_interface.py
@@ -3,7 +3,7 @@ import sys
 
 process = subprocess.Popen(["./build/debug/baBLE_linux"], stdout=subprocess.PIPE, stdin=subprocess.PIPE)
 
-process.stdin.write("1")
+process.stdin.write("2,0")
 
 try:
     while True:

--- a/python_interface.py
+++ b/python_interface.py
@@ -1,9 +1,14 @@
 import subprocess
 import sys
+import time
 
 process = subprocess.Popen(["./build/debug/baBLE_linux"], stdout=subprocess.PIPE, stdin=subprocess.PIPE)
 
 process.stdin.write("2,0")
+
+time.sleep(2)
+
+process.stdin.write("5,0")
 
 try:
     while True:

--- a/src/Builder/AbstractBuilder.hpp
+++ b/src/Builder/AbstractBuilder.hpp
@@ -11,6 +11,21 @@ using PacketConstructor = std::function<std::unique_ptr<Packet::AbstractPacket>(
 class AbstractBuilder {
 
 public:
+  AbstractBuilder() = default;
+
+  explicit AbstractBuilder(Packet::Type default_translated_type) {
+    m_default_translated_type = default_translated_type;
+  }
+
+  template<class T>
+  AbstractBuilder& register_command() {
+    if (m_default_translated_type == 0) {
+      throw std::invalid_argument("Missing argument 'translated_type' to register command.");
+    }
+
+    return register_command<T>(m_default_translated_type);
+  };
+
   template<class T>
   AbstractBuilder& register_command(Packet::Type translated_type) {
     const Packet::Type initial_type = packet_type();
@@ -26,6 +41,15 @@ public:
     };
 
     return *this;
+  };
+
+  template<class T>
+  AbstractBuilder& register_event() {
+    if (m_default_translated_type == 0) {
+      throw std::invalid_argument("Missing argument 'translated_type' to register event.");
+    }
+
+    return register_event<T>(m_default_translated_type);
   };
 
   template<class T>
@@ -52,6 +76,8 @@ protected:
 
   std::unordered_map<uint16_t, PacketConstructor> m_commands;
   std::unordered_map<uint16_t, PacketConstructor> m_events;
+
+  Packet::Type m_default_translated_type;
 
 };
 

--- a/src/Builder/Ascii/AsciiBuilder.hpp
+++ b/src/Builder/Ascii/AsciiBuilder.hpp
@@ -10,10 +10,26 @@
 class AsciiBuilder : public AbstractBuilder {
 
 public:
+  using AbstractBuilder::AbstractBuilder;
+
+  static std::string extract_command_code(const Deserializer& deser) {
+    Deserializer tmp_deser = deser;
+    std::string data_str;
+    tmp_deser >> data_str;
+
+    size_t pos = data_str.find(Packet::Commands::Ascii::Delimiter);
+
+    if (pos == std::string::npos) {
+      return data_str;
+    }
+
+    std::string command_code_str = data_str.substr(0, pos);
+    return command_code_str;
+  }
+
   std::unique_ptr<Packet::AbstractPacket> build(Deserializer& deser) override {
-    // Extract event_code from deser
-    std::string command_code_str;
-    deser >> command_code_str;
+    std::string command_code_str = extract_command_code(deser);
+
     auto command_code = static_cast<uint16_t>(stoi(command_code_str));
 
     auto it = m_commands.find(command_code);
@@ -21,7 +37,6 @@ public:
       throw std::invalid_argument("Command code not found");
     }
 
-    // Get command from command_code
     PacketConstructor fn = it->second;
     std::unique_ptr<Packet::AbstractPacket> packet = fn();
     packet->unserialize(deser);

--- a/src/Packet/Commands/GetMGMTInfo/GetMGMTInfo.hpp
+++ b/src/Packet/Commands/GetMGMTInfo/GetMGMTInfo.hpp
@@ -7,7 +7,7 @@
 
 namespace Packet::Commands {
 
-  class GetMGMTInfo : public CommandPacket {
+  class GetMGMTInfo : public CommandPacket<GetMGMTInfo> {
 
   public:
     static const uint16_t command_code(Packet::Type type) {
@@ -27,12 +27,14 @@ namespace Packet::Commands {
       m_command_code = command_code(m_current_type);
     };
 
-    void from_ascii() override {};
+    void from_ascii(const std::vector<std::string>& params) override {};
+
+    std::string to_ascii() const override {
+      return CommandPacket::to_ascii();
+    };
 
     Serializer to_mgmt() const override {
-      Serializer ser;
-      generate_header(ser);
-      return ser;
+      return CommandPacket::to_mgmt();
     };
 
   };

--- a/src/Packet/Commands/Scan/StartScan.cpp
+++ b/src/Packet/Commands/Scan/StartScan.cpp
@@ -1,0 +1,1 @@
+#include "StartScan.hpp"

--- a/src/Packet/Commands/Scan/StartScan.hpp
+++ b/src/Packet/Commands/Scan/StartScan.hpp
@@ -1,0 +1,63 @@
+#ifndef BABLE_LINUX_COMMANDS_STARTSCAN_HPP
+#define BABLE_LINUX_COMMANDS_STARTSCAN_HPP
+
+#include <cstdint>
+#include "../CommandPacket.hpp"
+#include "../../constants.hpp"
+
+namespace Packet::Commands {
+
+  class StartScan : public CommandPacket<StartScan> {
+
+  public:
+    static const uint16_t command_code(Packet::Type type) {
+      switch(type) {
+        case Packet::Type::MGMT:
+          return Commands::MGMT::Code::StartScan;
+
+        case Packet::Type::ASCII:
+          return Commands::Ascii::Code::StartScan;
+
+        default:
+          throw std::runtime_error("Current type has no known id.");
+      }
+    };
+
+    StartScan(Packet::Type initial_type, Packet::Type translated_type): CommandPacket(initial_type, translated_type) {
+      m_address_type = 0x06;
+      m_params_length = 1;
+    };
+
+    void from_ascii(const std::vector<std::string>& params) override {
+      if (params.size() < 2) {
+        throw std::invalid_argument("Missing arguments for 'start_scan' packet. Usage: <command_code>,<controller_id>");
+      }
+
+      std::string controller_id_str = params.at(1);
+      m_controller_id = static_cast<uint16_t>(stoi(controller_id_str));
+    };
+
+    std::string to_ascii() const override {
+      std::string header = CommandPacket::to_ascii();
+      std::stringstream payload;
+
+      payload << "Address type: " << std::to_string(m_address_type);
+
+
+      return header + ", " + payload.str();
+    };
+
+    Serializer to_mgmt() const override {
+      Serializer ser = CommandPacket::to_mgmt();
+      ser << m_address_type;
+      return ser;
+    };
+
+  private:
+    uint8_t m_address_type;
+
+  };
+
+}
+
+#endif //BABLE_LINUX_COMMANDS_STARTSCAN_HPP

--- a/src/Packet/Commands/Scan/StartScan.hpp
+++ b/src/Packet/Commands/Scan/StartScan.hpp
@@ -24,7 +24,7 @@ namespace Packet::Commands {
     };
 
     StartScan(Packet::Type initial_type, Packet::Type translated_type): CommandPacket(initial_type, translated_type) {
-      m_address_type = 0x06;
+      m_address_type = 0x06; // All BLE devices
       m_params_length = 1;
     };
 

--- a/src/Packet/Commands/Scan/StopScan.cpp
+++ b/src/Packet/Commands/Scan/StopScan.cpp
@@ -1,0 +1,1 @@
+#include "StopScan.hpp"

--- a/src/Packet/Commands/Scan/StopScan.hpp
+++ b/src/Packet/Commands/Scan/StopScan.hpp
@@ -1,5 +1,5 @@
-#ifndef BABLE_LINUX_COMMANDS_STARTSCAN_HPP
-#define BABLE_LINUX_COMMANDS_STARTSCAN_HPP
+#ifndef BABLE_LINUX_COMMANDS_STOPSCAN_HPP
+#define BABLE_LINUX_COMMANDS_STOPSCAN_HPP
 
 #include <cstdint>
 #include "../CommandPacket.hpp"
@@ -7,30 +7,30 @@
 
 namespace Packet::Commands {
 
-  class StartScan : public CommandPacket<StartScan> {
+  class StopScan : public CommandPacket<StopScan> {
 
   public:
     static const uint16_t command_code(Packet::Type type) {
       switch(type) {
         case Packet::Type::MGMT:
-          return Commands::MGMT::Code::StartScan;
+          return Commands::MGMT::Code::StopScan;
 
         case Packet::Type::ASCII:
-          return Commands::Ascii::Code::StartScan;
+          return Commands::Ascii::Code::StopScan;
 
         default:
           throw std::runtime_error("Current type has no known id.");
       }
     };
 
-    StartScan(Packet::Type initial_type, Packet::Type translated_type): CommandPacket(initial_type, translated_type) {
+    StopScan(Packet::Type initial_type, Packet::Type translated_type): CommandPacket(initial_type, translated_type) {
       m_address_type = 0x06; // All BLE devices
       m_params_length = 1;
     };
 
     void from_ascii(const std::vector<std::string>& params) override {
       if (params.size() < 2) {
-        throw std::invalid_argument("Missing arguments for 'start_scan' packet. Usage: <command_code>,<controller_id>");
+        throw std::invalid_argument("Missing arguments for 'stop_scan' packet. Usage: <command_code>,<controller_id>");
       }
 
       std::string controller_id_str = params.at(1);
@@ -59,4 +59,4 @@ namespace Packet::Commands {
 
 }
 
-#endif //BABLE_LINUX_COMMANDS_STARTSCAN_HPP
+#endif //BABLE_LINUX_COMMANDS_STOPSCAN_HPP

--- a/src/Packet/Events/DeviceFound/DeviceFound.cpp
+++ b/src/Packet/Events/DeviceFound/DeviceFound.cpp
@@ -1,0 +1,1 @@
+#include "DeviceFound.hpp"

--- a/src/Packet/Events/DeviceFound/DeviceFound.hpp
+++ b/src/Packet/Events/DeviceFound/DeviceFound.hpp
@@ -1,0 +1,157 @@
+#ifndef BABLE_LINUX_DEVICEFOUND_HPP
+#define BABLE_LINUX_DEVICEFOUND_HPP
+
+#include <cstdint>
+#include "../EventPacket.hpp"
+#include "../../../Serializer/Deserializer.hpp"
+#include "../../../Log/Log.hpp"
+
+namespace Packet::Events {
+
+  class DeviceFound : public EventPacket<DeviceFound> {
+
+  public:
+    static const uint16_t event_code(Packet::Type type) {
+      switch(type) {
+        case Packet::Type::MGMT:
+          return Events::MGMT::Code::DeviceFound;
+
+        case Packet::Type::ASCII:
+          return Events::Ascii::Code::DeviceFound;
+
+        default:
+          throw std::runtime_error("Current type has no known id.");
+      }
+    };
+
+    DeviceFound(Packet::Type initial_type, Packet::Type translated_type): EventPacket(initial_type, translated_type) {
+      m_address = std::array<uint8_t, 6>{0, 0, 0, 0, 0, 0};
+      m_address_type = 0;
+      m_rssi = 0;
+      m_flags = std::array<uint8_t, 4>{0, 0, 0, 0};
+      m_eir_data_length = 0;
+
+      m_eir_flags = 0;
+      m_uuid =  std::array<uint8_t, 16>{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+      m_company_id = 0;
+    };
+
+    void from_mgmt(Deserializer& deser) override {
+      EventPacket::from_mgmt(deser);
+      deser >> m_address >> m_address_type >> m_rssi >> m_flags >> m_eir_data_length;
+      m_eir_data.resize(m_eir_data_length);
+      deser >> m_eir_data;
+      extract_eir(m_eir_data);
+    };
+
+    std::string to_ascii() const override {
+      std::string header = EventPacket::to_ascii();
+      std::stringstream payload;
+
+      payload << "Address: " << format_bd_address(m_address) << ", "
+              << "Address type: " << std::to_string(m_address_type) << ", "
+              << "RSSI: " << std::to_string(m_rssi) << ", "
+              << "Flags: " << std::to_string(m_flags[0]) << " " << std::to_string(m_flags[1]) << " " << std::to_string(m_flags[2]) << " " << std::to_string(m_flags[3]) << ", "
+              << "EIR data length: " << std::to_string(m_eir_data_length) << ", "
+              << "EIR flags: " << std::to_string(m_eir_flags) << ", "
+              << "EIR UUID: " << format_uuid(m_uuid) << ", "
+              << "EIR Company ID: " << std::to_string(m_company_id) << ", "
+              << "EIR Device Name: " << format_device_name(m_device_name) << ", ";
+
+      return header + ", " + payload.str();
+    };
+
+  private:
+    static std::string format_bd_address(const std::array<uint8_t, 6>& bd_address_array) {
+      std::stringstream bd_address;
+
+      for(auto it = bd_address_array.rbegin(); it != bd_address_array.rend(); ++it) {
+        bd_address << RAW_HEX(*it, 2);
+        if (std::next(it) != bd_address_array.rend()) {
+          bd_address << ":";
+        }
+      }
+
+      return bd_address.str();
+    }
+
+    static std::string format_uuid(const std::array<uint8_t, 16>& uuid_array) {
+      std::stringstream uuid;
+
+      for(auto& v : uuid_array) {
+        uuid << RAW_HEX(v, 2);
+      }
+
+      return uuid.str();
+    }
+
+    static std::string format_device_name(const std::vector<uint8_t>& device_name_array) {
+      std::stringstream device_name;
+
+      for(auto& v : device_name_array) {
+        device_name << char(v);
+      }
+
+      return device_name.str();
+    }
+
+    void extract_eir(const std::vector<uint8_t>& eir) {
+      if (eir.size() < 3) {
+        return;
+      }
+
+      for(auto it = eir.begin(); it != eir.end(); ++it) {
+        uint8_t field_length = *it;
+        if(++it == eir.end()) return;
+
+        uint8_t type = *it;
+        if(++it == eir.end()) return;
+
+        field_length--;
+
+        switch(type) {
+          case 0x01: // Flags
+            m_eir_flags = *it;
+            break;
+
+          case 0x06: // 128bits UUID
+          case 0x07:
+            std::copy(it, it + 16, m_uuid.begin());
+            break;
+
+          case 0xFF: // Manufacturer Specific
+            m_company_id = (*it << 8) | *(it + 1);
+            break;
+
+          case 0x09: // Device complete name
+            m_device_name.resize(field_length);
+            std::copy(it, it + field_length, m_device_name.begin());
+            break;
+
+          default:
+            LOG.debug("Unknown EIR type received: " + std::to_string(type), "DeviceFoundEvent");
+            break;
+        }
+
+        for(uint8_t i = 0; i < field_length - 1; i++) {
+          if(++it == eir.end()) return;
+        }
+      }
+    }
+
+    std::array<uint8_t, 6> m_address{};
+    uint8_t m_address_type;
+    uint8_t m_rssi;
+    std::array<uint8_t, 4> m_flags{};
+    uint16_t m_eir_data_length;
+    std::vector<uint8_t> m_eir_data;
+
+    uint8_t m_eir_flags;
+    std::array<uint8_t, 16> m_uuid{};
+    uint16_t m_company_id;
+    std::vector<uint8_t> m_device_name;
+  };
+
+}
+
+#endif //BABLE_LINUX_DEVICEFOUND_HPP

--- a/src/Packet/Events/Discovering/Discovering.cpp
+++ b/src/Packet/Events/Discovering/Discovering.cpp
@@ -1,0 +1,1 @@
+#include "Discovering.hpp"

--- a/src/Packet/Events/Discovering/Discovering.hpp
+++ b/src/Packet/Events/Discovering/Discovering.hpp
@@ -1,0 +1,53 @@
+#ifndef BABLE_LINUX_DISCOVERING_HPP
+#define BABLE_LINUX_DISCOVERING_HPP
+
+#include <cstdint>
+#include "../EventPacket.hpp"
+#include "../../../Serializer/Deserializer.hpp"
+
+namespace Packet::Events {
+
+  class Discovering : public EventPacket<Discovering> {
+
+  public:
+    static const uint16_t event_code(Packet::Type type) {
+      switch(type) {
+        case Packet::Type::MGMT:
+          return Events::MGMT::Code::Discovering;
+
+        case Packet::Type::ASCII:
+          return Events::Ascii::Code::Discovering;
+
+        default:
+          throw std::runtime_error("Current type has no known id.");
+      }
+    };
+
+    Discovering(Packet::Type initial_type, Packet::Type translated_type): EventPacket(initial_type, translated_type) {
+      m_address_type = 0;
+      m_discovering = 0;
+    };
+
+    void from_mgmt(Deserializer& deser) override {
+      EventPacket::from_mgmt(deser);
+      deser >> m_address_type >> m_discovering;
+    };
+
+    std::string to_ascii() const override {
+      std::string header = EventPacket::to_ascii();
+      std::stringstream payload;
+
+      payload << "Address type: " << std::to_string(m_address_type) << ", "
+              << "Discovering: " << std::to_string(m_discovering);
+
+      return header + ", " + payload.str();
+    };
+
+  private:
+    uint8_t m_address_type;
+    uint8_t m_discovering;
+  };
+
+}
+
+#endif //BABLE_LINUX_DISCOVERING_HPP

--- a/src/Packet/Events/EventPacket.hpp
+++ b/src/Packet/Events/EventPacket.hpp
@@ -1,21 +1,19 @@
-#ifndef BABLE_LINUX_RESPONSEPACKET_HPP
-#define BABLE_LINUX_RESPONSEPACKET_HPP
+#ifndef BABLE_LINUX_EVENTPACKET_HPP
+#define BABLE_LINUX_EVENTPACKET_HPP
 
 #include "../AbstractPacket.hpp"
 #include "../../Serializer/Deserializer.hpp"
 
-namespace Packet::Responses {
+namespace Packet::Events {
 
   template<class T>
-  class ResponsePacket : public AbstractPacket {
+  class EventPacket : public AbstractPacket {
 
   protected:
-    ResponsePacket(Packet::Type initial_type, Packet::Type translated_type): AbstractPacket(initial_type, translated_type) {
+    EventPacket(Packet::Type initial_type, Packet::Type translated_type): AbstractPacket(initial_type, translated_type) {
       m_event_code = 0;
       m_controller_id = 0xFFFF;
       m_params_length = 0;
-      m_command_code = T::command_code(m_current_type);
-      m_status = 0;
     };
 
     std::string to_ascii() const override {
@@ -26,29 +24,21 @@ namespace Packet::Responses {
     };
 
     void from_mgmt(Deserializer& deser) override {
-      deser >> m_event_code >> m_controller_id >> m_params_length >> m_command_code >> m_status;
-    };
-
-    void after_translate() override {
-      m_command_code = T::command_code(m_current_type);
+      deser >> m_event_code >> m_controller_id >> m_params_length;
     };
 
     uint16_t m_event_code;
     uint16_t m_controller_id;
     uint16_t m_params_length;
-    uint16_t m_command_code;
-    uint8_t m_status;
 
   private:
     void generate_header(std::stringstream& str) const {
       switch(m_current_type) {
         case Packet::ASCII:
-          str << "<ResponsePacket> "
+          str << "<EventPacket> "
               << "Event code: " << std::to_string(m_event_code) << ", "
               << "Controller ID: " << std::to_string(m_controller_id) << ", "
-              << "Parameters length: " << std::to_string(m_params_length) << ", "
-              << "Command code: " << std::to_string(m_command_code) << ", "
-              << "Status: " << std::to_string(m_status);
+              << "Parameters length: " << std::to_string(m_params_length);
           break;
 
         default:
@@ -60,4 +50,4 @@ namespace Packet::Responses {
 
 }
 
-#endif //BABLE_LINUX_RESPONSEPACKET_HPP
+#endif //BABLE_LINUX_EVENTPACKET_HPP

--- a/src/Packet/Responses/Scan/StartScan.cpp
+++ b/src/Packet/Responses/Scan/StartScan.cpp
@@ -1,0 +1,1 @@
+#include "StartScan.hpp"

--- a/src/Packet/Responses/Scan/StartScan.hpp
+++ b/src/Packet/Responses/Scan/StartScan.hpp
@@ -1,5 +1,5 @@
-#ifndef BABLE_LINUX_RESPONSES_GETMGMTINFO_HPP
-#define BABLE_LINUX_RESPONSES_GETMGMTINFO_HPP
+#ifndef BABLE_LINUX_RESPONSES_STARTSCAN_HPP
+#define BABLE_LINUX_RESPONSES_STARTSCAN_HPP
 
 #include <cstdint>
 #include "../ResponsePacket.hpp"
@@ -7,48 +7,45 @@
 
 namespace Packet::Responses {
 
-  class GetMGMTInfo : public ResponsePacket<GetMGMTInfo> {
+  class StartScan : public ResponsePacket<StartScan> {
 
   public:
     static const uint16_t command_code(Packet::Type type) {
       switch(type) {
         case Packet::Type::MGMT:
-          return Commands::MGMT::Code::GetMGMTInfo;
+          return Commands::MGMT::Code::StartScan;
 
         case Packet::Type::ASCII:
-          return Commands::Ascii::Code::GetMGMTInfo;
+          return Commands::Ascii::Code::StartScan;
 
         default:
           throw std::runtime_error("Current type has no known id.");
       }
     };
 
-    GetMGMTInfo(Packet::Type initial_type, Packet::Type translated_type): ResponsePacket(initial_type, translated_type) {
-      m_version = 0;
-      m_revision = 0;
+    StartScan(Packet::Type initial_type, Packet::Type translated_type): ResponsePacket(initial_type, translated_type) {
+      m_address_type = 0;
     };
 
     void from_mgmt(Deserializer& deser) override {
       ResponsePacket::from_mgmt(deser);
-      deser >> m_version >> m_revision;
+      deser >> m_address_type;
     };
 
     std::string to_ascii() const override {
       std::string header = ResponsePacket::to_ascii();
       std::stringstream payload;
 
-      payload << "Version: " << std::to_string(m_version) << ", "
-              << "Revision: " << std::to_string(m_revision);
+      payload << "Address type: " << std::to_string(m_address_type);
 
 
       return header + ", " + payload.str();
     };
 
   private:
-    uint8_t m_version;
-    uint16_t m_revision;
+    uint8_t m_address_type;
   };
 
 }
 
-#endif //BABLE_LINUX_RESPONSES_GETMGMTINFO_HPP
+#endif //BABLE_LINUX_RESPONSES_STARTSCAN_HPP

--- a/src/Packet/Responses/Scan/StopScan.cpp
+++ b/src/Packet/Responses/Scan/StopScan.cpp
@@ -1,0 +1,1 @@
+#include "StopScan.hpp"

--- a/src/Packet/Responses/Scan/StopScan.hpp
+++ b/src/Packet/Responses/Scan/StopScan.hpp
@@ -1,0 +1,51 @@
+#ifndef BABLE_LINUX_RESPONSES_STOPSCAN_HPP
+#define BABLE_LINUX_RESPONSES_STOPSCAN_HPP
+
+#include <cstdint>
+#include "../ResponsePacket.hpp"
+#include "../../constants.hpp"
+
+namespace Packet::Responses {
+
+  class StopScan : public ResponsePacket<StopScan> {
+
+  public:
+    static const uint16_t command_code(Packet::Type type) {
+      switch(type) {
+        case Packet::Type::MGMT:
+          return Commands::MGMT::Code::StopScan;
+
+        case Packet::Type::ASCII:
+          return Commands::Ascii::Code::StopScan;
+
+        default:
+          throw std::runtime_error("Current type has no known id.");
+      }
+    };
+
+    StopScan(Packet::Type initial_type, Packet::Type translated_type): ResponsePacket(initial_type, translated_type) {
+      m_address_type = 0;
+    };
+
+    void from_mgmt(Deserializer& deser) override {
+      ResponsePacket::from_mgmt(deser);
+      deser >> m_address_type;
+    };
+
+    std::string to_ascii() const override {
+      std::string header = ResponsePacket::to_ascii();
+      std::stringstream payload;
+
+      payload << "Address type: " << std::to_string(m_address_type);
+
+
+      return header + ", " + payload.str();
+    };
+
+  private:
+    uint8_t m_address_type;
+  };
+
+}
+
+#endif //BABLE_LINUX_RESPONSES_STOPSCAN_HPP

--- a/src/Packet/constants.hpp
+++ b/src/Packet/constants.hpp
@@ -1,6 +1,9 @@
 #ifndef BABLE_LINUX_MGMT_CODES_HPP
 #define BABLE_LINUX_MGMT_CODES_HPP
 
+#include <string>
+#include <unordered_map>
+
 namespace Packet {
 
   enum Type {
@@ -12,13 +15,69 @@ namespace Packet {
   namespace Commands {
     namespace MGMT {
       enum Code {
-        GetMGMTInfo= 0x0001
+        GetMGMTInfo= 0x0001,
+        StartScan= 0x0023
       };
     }
 
     namespace Ascii {
       enum Code {
-        GetMGMTInfo= 0x0001
+        GetMGMTInfo= 0x0001,
+        StartScan= 0x0002
+      };
+
+      const char Delimiter = ',';
+    }
+  }
+
+  namespace Status {
+    namespace MGMT {
+      enum Code {
+        Success= 0x00,
+        UnknownCommand= 0x01,
+        NotConnected= 0x02,
+        Failed= 0x03,
+        ConnectFailed= 0x04,
+        AuthenticationFailed= 0x05,
+        NotPaired= 0x06,
+        NoResources= 0x07,
+        Timeout= 0x08,
+        AlreadyConnected= 0x09,
+        Busy= 0x0A,
+        Rejected= 0x0B,
+        NotSupported= 0x0C,
+        InvalidParameters= 0x0D,
+        Disconnected= 0x0E,
+        NotPowered= 0x0F,
+        Cancelled= 0x10,
+        InvalidIndex= 0x11,
+        RFKilled= 0x12,
+        AlreadyPaired= 0x13,
+        PermissionDenied= 0x14
+      };
+
+      const std::unordered_map<uint8_t, std::string> ToString = {
+          { Code::Success, "Success" },
+          { Code::UnknownCommand, "Unknown command" },
+          { Code::NotConnected, "Not connected" },
+          { Code::Failed, "Failed" },
+          { Code::ConnectFailed, "Connect failed" },
+          { Code::AuthenticationFailed, "Authentication failed" },
+          { Code::NotPaired, "Not paired" },
+          { Code::NoResources, "No resources" },
+          { Code::Timeout, "Timeout" },
+          { Code::AlreadyConnected, "Already connected" },
+          { Code::Busy, "Busy" },
+          { Code::Rejected, "Rejected" },
+          { Code::NotSupported, "Not supported" },
+          { Code::InvalidParameters, "Invalid parameters" },
+          { Code::Disconnected, "Disconnected" },
+          { Code::NotPowered, "Not powered" },
+          { Code::Cancelled, "Cancelled" },
+          { Code::InvalidIndex, "Invalid index" },
+          { Code::RFKilled, "RF killed" },
+          { Code::AlreadyPaired, "Already paired" },
+          { Code::PermissionDenied, "Permission denied" },
       };
     }
   }

--- a/src/Packet/constants.hpp
+++ b/src/Packet/constants.hpp
@@ -16,14 +16,16 @@ namespace Packet {
     namespace MGMT {
       enum Code {
         GetMGMTInfo= 0x0001,
-        StartScan= 0x0023
+        StartScan= 0x0023,
+        StopScan= 0x0024
       };
     }
 
     namespace Ascii {
       enum Code {
         GetMGMTInfo= 0x0001,
-        StartScan= 0x0002
+        StartScan= 0x0002,
+        StopScan= 0x005
       };
 
       const char Delimiter = ',';

--- a/src/Packet/constants.hpp
+++ b/src/Packet/constants.hpp
@@ -30,6 +30,22 @@ namespace Packet {
     }
   }
 
+  namespace Events {
+    namespace MGMT {
+      enum Code {
+        DeviceFound= 0x0012,
+        Discovering= 0x0013
+      };
+    }
+
+    namespace Ascii {
+      enum Code {
+        DeviceFound= 0x003,
+        Discovering= 0x004
+      };
+    }
+  }
+
   namespace Status {
     namespace MGMT {
       enum Code {

--- a/src/Serializer/Deserializer.hpp
+++ b/src/Serializer/Deserializer.hpp
@@ -4,7 +4,7 @@
 #include <algorithm>
 #include <array>
 #include <cstdint>
-#include <cstring>
+#include <string>
 #include <vector>
 
 #include "AbstractSerializer.hpp"

--- a/src/Serializer/Serializer.hpp
+++ b/src/Serializer/Serializer.hpp
@@ -3,7 +3,7 @@
 
 #include <array>
 #include <cstdint>
-#include <cstring>
+#include <string>
 #include <vector>
 
 #include "AbstractSerializer.hpp"

--- a/src/Socket/MGMT/MGMTSocket.cpp
+++ b/src/Socket/MGMT/MGMTSocket.cpp
@@ -37,9 +37,8 @@ bool MGMTSocket::send(std::unique_ptr<Packet::AbstractPacket> packet) {
 
     set_writable(false);
     if (write(m_socket, ser.buffer(), ser.size()) < 0) {
-      LOG.error("Error while sending a message to MGMT socket. Queuing...");
-      m_send_queue.push(std::move(packet));
-      return false;
+      LOG.error("Error while sending a message to MGMT socket.");
+      throw std::runtime_error("Error occured while sending the packet through MGMT socket.");
     }
   }
 

--- a/src/Socket/MGMT/MGMTSocket.hpp
+++ b/src/Socket/MGMT/MGMTSocket.hpp
@@ -24,6 +24,7 @@ struct sockaddr_hci {
   unsigned short  hci_channel;
 };
 
+// TODO: idea -> run poller in socket ?
 class MGMTSocket : public AbstractSocket {
 
 public:

--- a/src/Socket/StdIO/StdIOSocket.hpp
+++ b/src/Socket/StdIO/StdIOSocket.hpp
@@ -38,6 +38,13 @@ public:
     return true;
   };
 
+  bool send(const std::string& str) {
+    std::string data_str = str + "\n";
+    fwrite(data_str.c_str(), sizeof(char), data_str.size(), stdout);
+    fflush(stdout);
+    return true;
+  };
+
   Deserializer receive(const char* data, size_t length) override {
     Deserializer deser;
     deser.import((uint8_t*)(data), length);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,12 +7,14 @@
 #include "Builder/Ascii/AsciiBuilder.hpp"
 #include "Builder/MGMT/MGMTBuilder.hpp"
 #include "Packet/constants.hpp"
-#include "Packet/Responses/GetMGMTInfo/GetMGMTInfo.hpp"
-#include "Packet/Commands/GetMGMTInfo/GetMGMTInfo.hpp"
 #include "Poller/Poller.hpp"
 #include "Poller/PipePoller.hpp"
+#include "Packet/Commands/GetMGMTInfo/GetMGMTInfo.hpp"
+#include "Packet/Responses/GetMGMTInfo/GetMGMTInfo.hpp"
 #include "Packet/Commands/Scan/StartScan.hpp"
 #include "Packet/Responses/Scan/StartScan.hpp"
+#include "Packet/Commands/Scan/StopScan.hpp"
+#include "Packet/Responses/Scan/StopScan.hpp"
 #include "Packet/Events/DeviceFound/DeviceFound.hpp"
 #include "Packet/Events/Discovering/Discovering.hpp"
 
@@ -28,6 +30,7 @@ void cleanly_stop_loop(Loop& loop) {
 }
 
 // TODO: handle errors properly (if exception OR status in complete event OR status in status event) -> forward to bable socket
+// TODO: idea -> put all registration into a bootstap.cpp file with a bootstrap() function
 int main() {
   ENABLE_LOGGING(DEBUG);
 
@@ -62,11 +65,13 @@ int main() {
   // Register packets into builder
   ascii_builder
       .register_command<Packet::Commands::GetMGMTInfo>(Packet::Type::MGMT)
-      .register_command<Packet::Commands::StartScan>(Packet::Type::MGMT);
+      .register_command<Packet::Commands::StartScan>(Packet::Type::MGMT)
+      .register_command<Packet::Commands::StopScan>(Packet::Type::MGMT);
 
   mgmt_builder
       .register_command<Packet::Responses::GetMGMTInfo>()
       .register_command<Packet::Responses::StartScan>()
+      .register_command<Packet::Responses::StopScan>()
       .register_event<Packet::Events::DeviceFound>()
       .register_event<Packet::Events::Discovering>();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,6 +13,8 @@
 #include "Poller/PipePoller.hpp"
 #include "Packet/Commands/Scan/StartScan.hpp"
 #include "Packet/Responses/Scan/StartScan.hpp"
+#include "Packet/Events/DeviceFound/DeviceFound.hpp"
+#include "Packet/Events/Discovering/Discovering.hpp"
 
 using namespace std;
 using namespace uvw;
@@ -64,7 +66,9 @@ int main() {
 
   mgmt_builder
       .register_command<Packet::Responses::GetMGMTInfo>()
-      .register_command<Packet::Responses::StartScan>();
+      .register_command<Packet::Responses::StartScan>()
+      .register_event<Packet::Events::DeviceFound>()
+      .register_event<Packet::Events::Discovering>();
 
   // Create pollers
   Poller mgmt_poller(loop, mgmt_socket->get_socket());

--- a/src/utils/stream_formats.hpp
+++ b/src/utils/stream_formats.hpp
@@ -3,6 +3,7 @@
 
 #include <iomanip>
 
-#define HEX(value) "0x" << std::setfill('0') << std::setw(2) << std::hex << static_cast<int>(value) << std::dec
+#define HEX(value) "0x" << RAW_HEX(value, 2)
+#define RAW_HEX(value, width) std::setfill('0') << std::setw(width) << std::hex << static_cast<int>(value) << std::dec
 
 #endif //BABLE_LINUX_STREAM_FORMATS_HPP


### PR DESCRIPTION
Add:
 - a "StartScan" command to start to scan nearby BLE devices
    - a response is sent back to confirm that the command has successfully been processed

 - a "Discovering" event is emitted as soon as the controller has started to pass into "discovering mode" to start the scan (meaning the scan has started). This event is also emitted when the controller has switched off the "discovery mode"

 - a "DeviceFound" event is emitted every time a device has been found. It contains its Mac address, its name, the RSSI and some flags

 - a "StopScan" command to stop the scan. At the moment, the scan automatically stops after 11 seconds (this could be set by using an HCI command). 11 seconds is the maximum recommended time and so MGMT sockets, by default, use this value...
    - a response is sent back to confirm that the command has successfully been processed